### PR TITLE
Lets peervpn execute with PID 1 => Graceful, quicker exit | Outputs l…

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # Create /etc/peervpn.conf if it does not exist.
 #
 if [ ! -f /etc/peervpn.conf ]; then
@@ -61,7 +63,7 @@ enabletunneling ${ENABLETUNNELING:-yes}
 ## Description:  Specifies the name of the TAP device that should be
 ##               used for ethernet tunneling.
 ##               Note: On some operating systems (e.g. FreeBSD), TAP
-##               device names must start with the string "tap".              
+##               device names must start with the string "tap".
 ## Example:      interface tap0
 ##               interface peervpn0
 
@@ -249,4 +251,4 @@ chmod 0600 /etc/peervpn.conf
 mkdir -p /dev/net
 mknod /dev/net/tun c 10 200
 
-/sbin/peervpn /etc/peervpn.conf > /var/log/peervpn.log 2>&1
+exec /sbin/peervpn /etc/peervpn.conf


### PR DESCRIPTION
Hi @mjuenema ,

thanks for your Docker container! Before using it myself, I did some little changes to the Docker entrypoint script:

1. Let the container exit gracefully e.g. on CTRL+C: The container could not exit gracefully, since peervpn was spawned by the script and thus received a PID other than 1. In my version the script hands over control to peervpn, so the peervpn process gets PID 1 and the container can be stopped much quicker (< 1 sec vs. 10 seconds process kill timeout)
2. Log peervpn output to console. This is considered best practise on Docker containers: For debugging and monitoring purpose, the process in the container should write its logs to the console. You can access the log via ```docker attach``` or ```docker-compose logs -f``` if you have started the container via ```docker-compose up -d``` before. Or otherwise: Just ignore the logs. Most probably you will run the container in detached / daemon mode anyway ;-) Most people expect the container to output some information about its state, so I was confused about the missing log, too.

If you like my changes I would be happy about a merge.